### PR TITLE
Fix ripple effect by retargeting react events to shadowroot.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,6 +1536,11 @@
         "@types/react": "*"
       }
     },
+    "@types/react-shadow-dom-retarget-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-shadow-dom-retarget-events/-/react-shadow-dom-retarget-events-1.0.0.tgz",
+      "integrity": "sha512-IVeyB+jl4l0j3QQxyouIMLc7T+6OqyYUKhaa2djyxrFJrL3BtEUhn2n5+IeRpvv1pwUl9yTUEyCeA98Gy2sexg=="
+    },
     "@types/react-transition-group": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.2.tgz",
@@ -2935,7 +2940,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3123,6 +3129,7 @@
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3223,6 +3230,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3298,7 +3306,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3346,6 +3355,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3384,11 +3394,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6843,7 +6855,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6861,11 +6874,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6878,15 +6893,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6989,7 +7007,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6999,6 +7018,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7011,17 +7031,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7038,6 +7061,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7110,7 +7134,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7120,6 +7145,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7195,7 +7221,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7225,6 +7252,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7242,6 +7270,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7280,11 +7309,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -10408,6 +10439,11 @@
         "webpack-manifest-plugin": "2.0.4",
         "workbox-webpack-plugin": "4.2.0"
       }
+    },
+    "react-shadow-dom-retarget-events": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/react-shadow-dom-retarget-events/-/react-shadow-dom-retarget-events-1.0.10.tgz",
+      "integrity": "sha512-OOt7ugDgSuXiy+PmMOMHqvm4ko6X+cJsre/N124dCJhLBXqv1xVLjwuhpeY7/nv7p/YxytvyfwYG+M19NMnSjQ=="
     },
     "react-transition-group": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "@types/node": "12.6.8",
     "@types/react": "16.8.23",
     "@types/react-dom": "16.8.4",
+    "@types/react-shadow-dom-retarget-events": "^1.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
+    "react-shadow-dom-retarget-events": "^1.0.10",
     "typescript": "3.5.3"
   },
   "scripts": {

--- a/src/ShadowDemo.tsx
+++ b/src/ShadowDemo.tsx
@@ -1,3 +1,5 @@
+import retargetEvents from 'react-shadow-dom-retarget-events'
+
 export class ShadowDomContainerExposingStyleInsertionPointAndSpaRoot extends HTMLElement {
   // don't understand why we have to have this reference internally (we can call it whatever)
   // since HTMLElement already exposes a general shadowRoot property, that will also hold reference to the same node it seems
@@ -23,6 +25,9 @@ export class ShadowDomContainerExposingStyleInsertionPointAndSpaRoot extends HTM
     this.SpaRoot = document.createElement("div");
     this.SpaRoot.setAttribute("id", "spa-root");
     this.InternalRootReference.appendChild(this.SpaRoot);
+
+    // retarget react events
+    retargetEvents(this.InternalRootReference);
   }
 }
 
@@ -51,5 +56,8 @@ export class ShadowDomContainerExposingStyleInsertionPointAndSpaRoot2 extends HT
     this.SpaRoot = document.createElement("div");
     this.SpaRoot.setAttribute("id", "spa-root");
     this.InternalRootReference.appendChild(this.SpaRoot);
+
+    // retarget react events
+    retargetEvents(this.InternalRootReference);
   }
 }


### PR DESCRIPTION
Fixes missing ripple effect on MUI buttons. Might not fix everything related to shadow DOM and event handling, but is shows that the problem occurs due to how React registers event handlers on the top level document, in order to put the events into their synthetic event system. The shadow root blocks the events from bubbling up to the handlers, swallowing the events. The react retargeting will register a bunch of event handlers on the shadowRoot and "manually" pass them directly to the react event handlers. 